### PR TITLE
chore(ci): pin reusable workflow refs + baseline policy doc

### DIFF
--- a/.github/WORKFLOW_BASELINE.md
+++ b/.github/WORKFLOW_BASELINE.md
@@ -1,0 +1,32 @@
+# Workflow Baseline Policy
+
+This repository defines the organization-level baseline for GitHub collaboration and CI hygiene.
+
+## Reusable workflow reference policy
+
+- Do **not** reference reusable workflows with floating refs such as `@master` or `@main`.
+- Use immutable refs:
+  - pinned commit SHA (preferred), or
+  - immutable release tag.
+
+Example:
+
+```yaml
+uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@88efd7724e007c8f721a219498be29e0c9ad471b
+```
+
+## Pull request baseline
+
+- Conventional Commit title required.
+- Semantic PR title check required.
+- CI checks must pass before merge.
+
+## Terraform module baseline (org standard)
+
+For Terraform module repositories, include:
+
+- `terraform.required_version` in `versions.tf`
+- explicit `required_providers` constraints
+- pinned shared workflow refs in `.github/workflows/*`
+
+These standards reduce supply-chain risk and improve CI reproducibility.

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   pr-validation:
     if: github.actor != 'dependabot[bot]'
-    uses: clouddrove/github-shared-workflows/.github/workflows/pr_checks.yml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/pr_checks.yml@88efd7724e007c8f721a219498be29e0c9ad471b
     secrets: inherit
     with:
       subjectPattern: '^.+$'

--- a/.github/workflows/stale_pr.yml
+++ b/.github/workflows/stale_pr.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-shared-stale:
-    uses: clouddrove/github-shared-workflows/.github/workflows/stale_pr.yml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/stale_pr.yml@88efd7724e007c8f721a219498be29e0c9ad471b
     with:
       days-before-issue-stale: 30
       days-before-pr-stale: 30

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tag-release.yml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/tag-release.yml@88efd7724e007c8f721a219498be29e0c9ad471b
     with:
       target_branch: master
     secrets:

--- a/.github/workflows/terraform-diff.yml
+++ b/.github/workflows/terraform-diff.yml
@@ -12,7 +12,7 @@ jobs:
 # Update 'Job name' and 'terraform_directory' as needed based on the module structure.
   private_pqsql_vnet_integration-example:
     if: github.actor != 'dependabot[bot]'
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-pr-checks.yaml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-pr-checks.yaml@88efd7724e007c8f721a219498be29e0c9ad471b
     with:
       provider: 'azurerm'
       terraform_directory: 'examples/private_pqsql_vnet_integration'
@@ -23,7 +23,7 @@ jobs:
 
   private_pqsql_with_private_endpoint-example:
     if: github.actor != 'dependabot[bot]'
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-pr-checks.yaml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-pr-checks.yaml@88efd7724e007c8f721a219498be29e0c9ad471b
     with:
       provider: 'azurerm'
       terraform_directory: 'examples/private_pqsql_with_private_endpoint'
@@ -34,7 +34,7 @@ jobs:
 
   public_pqsql-example:
     if: github.actor != 'dependabot[bot]'
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-pr-checks.yaml@master
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-pr-checks.yaml@88efd7724e007c8f721a219498be29e0c9ad471b
     with:
       provider: 'azurerm'
       terraform_directory: 'examples/public_pqsql_basic'


### PR DESCRIPTION
Add .github/WORKFLOW_BASELINE.md from org baseline repository to standardize policy expectations across module repos.