### PR TITLE
feat: Added azure extensions support for server configuration

### DIFF
--- a/examples/private_pqsql_vnet_integration/example.tf
+++ b/examples/private_pqsql_vnet_integration/example.tf
@@ -164,6 +164,13 @@ module "flexible-postgresql" {
   password_auth_enabled         = true      # ← must be true for psql CREATE EXTENSION step
   principal_name                = "test-db" # e.g., an AAD group name
 
+  # All server params in one map — no more parallel lists
+  server_configuration = {
+    "pgaudit.log"                         = "ALL"
+    "log_connections"                     = "on"
+    "idle_in_transaction_session_timeout" = "300000"
+  }
+
   # -------------------------------------------------------
   # pgvector
   # -------------------------------------------------------

--- a/examples/private_pqsql_vnet_integration/example.tf
+++ b/examples/private_pqsql_vnet_integration/example.tf
@@ -169,14 +169,8 @@ module "flexible-postgresql" {
     "pgaudit.log"                         = "ALL"
     "log_connections"                     = "on"
     "idle_in_transaction_session_timeout" = "300000"
+    "azure.extensions"                    = "VECTOR,PGAUDIT,BTREE_GIST,CITEXT,CUBE"
   }
 
-  # -------------------------------------------------------
-  # pgvector
-  # -------------------------------------------------------
-  enable_pgvector = true
-
-  # Optional: allowlist additional extensions alongside vector.
-  # azure_extensions = ["PGAUDIT", "BTREE_GIST", "CITEXT", "CUBE"]
   key_type = "RSA"
 }

--- a/examples/public_pqsql_basic/example.tf
+++ b/examples/public_pqsql_basic/example.tf
@@ -65,4 +65,16 @@ module "flexible-postgresql" {
     # }
   ]
 
+  # All server params in one map — no more parallel lists
+  server_configuration = {
+    "pgaudit.log"                         = "ALL"
+    "log_connections"                     = "on"
+    "idle_in_transaction_session_timeout" = "300000"
+  }
+
+  # azure.extensions is auto-built from these — do NOT add it to server_configuration
+  enable_pgvector = true
+  # azure_extensions = ["PGAUDIT", "BTREE_GIST", "CITEXT", "CUBE"]
+  # Results in: azure.extensions = "BTREE_GIST,CITEXT,CUBE,PGAUDIT,VECTOR"
+
 }

--- a/examples/public_pqsql_basic/example.tf
+++ b/examples/public_pqsql_basic/example.tf
@@ -70,11 +70,7 @@ module "flexible-postgresql" {
     "pgaudit.log"                         = "ALL"
     "log_connections"                     = "on"
     "idle_in_transaction_session_timeout" = "300000"
+    "azure.extensions"                    = "VECTOR,PGAUDIT,BTREE_GIST,CITEXT,CUBE"
   }
-
-  # azure.extensions is auto-built from these — do NOT add it to server_configuration
-  enable_pgvector = true
-  # azure_extensions = ["PGAUDIT", "BTREE_GIST", "CITEXT", "CUBE"]
-  # Results in: azure.extensions = "BTREE_GIST,CITEXT,CUBE,PGAUDIT,VECTOR"
 
 }

--- a/locals.tf
+++ b/locals.tf
@@ -3,22 +3,4 @@
 ##-----------------------------------------------------------------------------
 locals {
   name = var.custom_name != null ? var.custom_name : module.labels.id
-
-  # Extensions list — VECTOR auto-appended when enable_pgvector = true
-  azure_extensions_list = distinct([
-    for e in concat(
-      [for x in var.azure_extensions : upper(x)],
-      var.enable_pgvector ? ["VECTOR"] : []
-    ) : e
-  ])
-
-  # Merges user-provided server_configuration map with auto-computed
-  # azure.extensions value. If user accidentally puts azure.extensions
-  # in server_configuration, the auto-computed value wins (overrides it).
-  final_server_configuration = merge(
-    var.server_configuration,
-    length(local.azure_extensions_list) > 0 ? {
-      "azure.extensions" = join(",", local.azure_extensions_list)
-    } : {}
-  )
 }

--- a/locals.tf
+++ b/locals.tf
@@ -4,9 +4,7 @@
 locals {
   name = var.custom_name != null ? var.custom_name : module.labels.id
 
-  # Final list of extensions to allowlist. 'vector' is merged in automatically
-  # when enable_pgvector = true; duplicates are removed and names uppercased
-  # as Azure requires (e.g., "VECTOR,PG_TRGM").
+  # Extensions list — VECTOR auto-appended when enable_pgvector = true
   azure_extensions_list = distinct([
     for e in concat(
       [for x in var.azure_extensions : upper(x)],
@@ -14,4 +12,13 @@ locals {
     ) : e
   ])
 
+  # Merges user-provided server_configuration map with auto-computed
+  # azure.extensions value. If user accidentally puts azure.extensions
+  # in server_configuration, the auto-computed value wins (overrides it).
+  final_server_configuration = merge(
+    var.server_configuration,
+    length(local.azure_extensions_list) > 0 ? {
+      "azure.extensions" = join(",", local.azure_extensions_list)
+    } : {}
+  )
 }

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,6 @@ resource "random_password" "main" {
   special     = var.special
 }
 
-
 ##----------------------------------------------------------------------------- 
 ## Below resource will create postgresql flexible server.    
 ##-----------------------------------------------------------------------------
@@ -139,11 +138,19 @@ resource "azurerm_postgresql_flexible_server_database" "main" {
   depends_on = [azurerm_postgresql_flexible_server.main]
 }
 
+##-----------------------------------------------------------------------------
+## PostgreSQL Server Configuration
+## Manages all server parameters including azure.extensions (auto-injected
+## when enable_pgvector = true or azure_extensions is non-empty).
+##-----------------------------------------------------------------------------
 resource "azurerm_postgresql_flexible_server_configuration" "main" {
-  count     = var.enabled ? length(var.server_configuration_name) : 0
-  name      = element(var.server_configuration_name, count.index)
-  server_id = join("", azurerm_postgresql_flexible_server.main[*].id)
-  value     = element(var.values, count.index)
+  for_each = var.enabled ? local.final_server_configuration : {}
+
+  name      = each.key
+  server_id = azurerm_postgresql_flexible_server.main[0].id
+  value     = each.value
+
+  depends_on = [azurerm_postgresql_flexible_server.main]
 }
 
 
@@ -220,26 +227,6 @@ resource "azurerm_private_endpoint" "pep" {
       tags,
     ]
   }
-}
-
-##-----------------------------------------------------------------------------
-## pgvector – Allowlist extensions at the server level.
-## Azure mandates explicit allowlisting before CREATE EXTENSION can succeed.
-## 'vector' is added automatically when enable_pgvector = true.
-## Also handles any other extensions supplied via var.azure_extensions.
-##
-## ⚠ Do NOT pass 'azure.extensions' through var.server_configuration_name
-##   when using var.azure_extensions or var.enable_pgvector — doing so will
-##   create a duplicate resource conflict in Terraform state.
-##-----------------------------------------------------------------------------
-resource "azurerm_postgresql_flexible_server_configuration" "azure_extensions" {
-  count     = var.enabled && length(local.azure_extensions_list) > 0 ? 1 : 0
-  name      = "azure.extensions"
-  server_id = azurerm_postgresql_flexible_server.main[0].id
-  value     = join(",", local.azure_extensions_list)
-  depends_on = [azurerm_postgresql_flexible_server.main,
-    azurerm_postgresql_flexible_server_configuration.main,
-  ]
 }
 
 ##-----------------------------------------------------------------------------

--- a/main.tf
+++ b/main.tf
@@ -140,12 +140,10 @@ resource "azurerm_postgresql_flexible_server_database" "main" {
 
 ##-----------------------------------------------------------------------------
 ## PostgreSQL Server Configuration
-## Manages all server parameters including azure.extensions (auto-injected
-## when enable_pgvector = true or azure_extensions is non-empty).
+## Manages all server parameters including azure.extensions
 ##-----------------------------------------------------------------------------
 resource "azurerm_postgresql_flexible_server_configuration" "main" {
-  for_each = var.enabled ? local.final_server_configuration : {}
-
+  for_each  = var.enabled ? var.server_configuration : {}
   name      = each.key
   server_id = azurerm_postgresql_flexible_server.main[0].id
   value     = each.value

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,11 +8,6 @@ output "postgresql_flexible_server_name" {
   description = "The FQDN of the PostgreSQL Flexible Server."
 }
 
-output "pgvector_enabled" {
-  description = "Whether the pgvector extension was configured on this server."
-  value       = var.enable_pgvector
-}
-
 output "firewall_rule_ids" {
   description = "Map of firewall rule names to their resource IDs."
   value       = { for k, v in azurerm_postgresql_flexible_server_firewall_rule.main : k => v.id }

--- a/variables.tf
+++ b/variables.tf
@@ -433,25 +433,6 @@ variable "key_size" {
 }
 
 ##-----------------------------------------------------------------------------
-## pgvector Extension
-##-----------------------------------------------------------------------------
-variable "enable_pgvector" {
-  description = "Set to true to allowlist and install the pgvector (vector) extension on the PostgreSQL Flexible Server."
-  type        = bool
-  default     = false
-}
-
-variable "azure_extensions" {
-  description = <<-EOT
-    Additional PostgreSQL extensions to allowlist via the azure.extensions server parameter
-    (e.g., ["pg_trgm", "uuid-ossp"]). 'vector' is appended automatically when enable_pgvector = true.
-    Do NOT also pass 'azure.extensions' via server_configuration_name when using this variable.
-  EOT
-  type        = list(string)
-  default     = []
-}
-
-##-----------------------------------------------------------------------------
 ## PostgreSQL Firewall Rules
 ##-----------------------------------------------------------------------------
 variable "firewall_rules" {

--- a/variables.tf
+++ b/variables.tf
@@ -211,22 +211,16 @@ variable "location" {
   description = "The Azure Region where the PostgreSQL Flexible Server should exist. Changing this forces a new PostgreSQL Flexible Server to be created."
 }
 
-variable "server_configuration_name" {
-  type = list(string)
-  default = [
-    # "azure.extensions",
-    "pgaudit.log",
-  ]
-  description = "Specifies the name of the PostgreSQL Flexible Server Configuration, which needs to be a valid PostgreSQL configuration name. Changing this forces a new resource to be created."
-}
-
-variable "values" {
-  type = list(string)
-  default = [
-    # "CUBE,CITEXT,BTREE_GIST,PGAUDIT",
-    "ALL",
-  ]
-  description = "Specifies the value of the PostgreSQL Flexible Server Configuration. See the PostgreSQL documentation for valid values. Changing this forces a new resource to be created."
+variable "server_configuration" {
+  type = map(string)
+  default = {
+    "pgaudit.log" = "ALL"
+  }
+  description = <<-EOT
+    Map of PostgreSQL Flexible Server configuration parameters to their values.
+    azure.extensions is managed automatically — use var.azure_extensions and
+    var.enable_pgvector instead of setting it manually here to avoid conflicts.
+  EOT
 }
 
 variable "storage_mb" {


### PR DESCRIPTION
## Description

- Added support for azure extensions from server configuration only
- Removed extra block for extensions
- Turned map variable from list of strings for server_configuration 

<img width="904" height="360" alt="image" src="https://github.com/user-attachments/assets/01d17952-a0a0-4028-9b16-4737afcf6bc4" />

Fixes # 

Closes # 

---

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [X] Feature
- [ ] Feature (Breaking Change)
- [X] Fix
- [ ] Fix (Breaking Change)
- [ ] CI/CD
- [ ] Documentation
- [ ] Other (please specify):

---

## Checklist

- [X] I have reviewed open pull requests to avoid duplication of work
- [ ] All relevant pipelines or checks pass successfully
- [ ] I have added or updated documentation if applicable
