### PR TITLE
fix: private_dns_group_id of pe

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "azurerm_postgresql_flexible_server" "main" {
   administrator_password            = var.admin_password != null ? var.admin_password : (var.generate_random_password ? random_password.main[0].result : null)
   backup_retention_days             = var.backup_retention_days
   delegated_subnet_id               = var.delegated_subnet_id
-  private_dns_zone_id               = var.private_dns_zone_id
+  private_dns_zone_id               = var.vnet_int_private_dns_zone_id
   public_network_access_enabled     = var.public_network_access_enabled
   sku_name                          = var.sku_name
   create_mode                       = var.create_mode

--- a/variables.tf
+++ b/variables.tf
@@ -375,10 +375,16 @@ variable "private_endpoint_subnet_id" {
   description = "The subnet ID where the private endpoint will be deployed"
 }
 
-variable "private_dns_zone_id" {
+variable "vnet_int_private_dns_zone_id" {
   type        = string
   default     = null
   description = "The ID of the Private DNS Zone to associate with the PostgreSQL Flexible Server."
+}
+
+variable "private_dns_zone_id" {
+  type        = string
+  default     = null
+  description = "The ID of the Private DNS Zone to associate with the PostgreSQL Flexible Server Private Endpoint."
 }
 
 variable "geo_backup_key_vault_key_id" {


### PR DESCRIPTION
## Description
- defined a different variable for private dns group id of postgresql.
<!--
🎉 Thank you for your contribution!

Please provide a brief summary of the changes in this pull request, including:
- A short description of what the PR does
- The reason or motivation for the change
- Relevant issue references, e.g., Fixes #123 or Closes #456
- Any context that helps reviewers understand the impact or use case
- Dependencies introduced, if any
- Screenshots or logs, if applicable (e.g., UI changes or test outputs)
-->

Fixes # 

Closes # 

---

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Feature
- [ ] Feature (Breaking Change)
- [x] Fix
- [ ] Fix (Breaking Change)
- [ ] CI/CD
- [ ] Documentation
- [ ] Other (please specify):

---

## Checklist

- [ ] I have reviewed open pull requests to avoid duplication of work
- [ ] All relevant pipelines or checks pass successfully
- [ ] I have added or updated documentation if applicable
